### PR TITLE
Accept Meta class inside entity models to override datastore.Client instance params

### DIFF
--- a/noseiquela_orm/client.py
+++ b/noseiquela_orm/client.py
@@ -1,18 +1,32 @@
+from typing import Callable, Dict
 from functools import partial
 
 from google.cloud import datastore
+from google.cloud.datastore.client import _CLIENT_INFO
+from google.cloud.datastore.entity import Entity as GoogleEntity
 
 
 class DataStoreClient:
-    _instance = None
-
-    def __init__(self) -> None:
-        self._client = datastore.Client()
-
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
+    def __init__(self,
+        project=None,
+        namespace=None,
+        credentials=None,
+        client_info=None,
+        client_options=None,
+        _http=None,
+        _use_grpc=None
+    ) -> None:
+        self._project = project
+        self._namespace = namespace
+        self._client = datastore.Client(
+            project=project,
+            namespace=namespace,
+            credentials=credentials,
+            client_info=(client_info or _CLIENT_INFO),
+            client_options=client_options,
+            _http=_http,
+            _use_grpc=_use_grpc
+        )
 
     def _get_partial_query(self, kind):
         return partial(
@@ -28,10 +42,19 @@ class DataStoreClient:
         )
         return entity.key.id
 
+    def _mount_google_entity(self, entity_dict: Dict, key_case: Callable) -> GoogleEntity:
+        entity_key = entity_dict.pop("id")
+        entity = GoogleEntity(entity_key)
+        for key, value in entity_dict.items():
+            key_name = key_case(key)
+            entity[key_name] = value
+
+        return entity
+
     @property
     def project(self):
-        return self._client.project
+        return self._project or self._client.project
 
     @property
     def namespace(self):
-        return self._client.namespace
+        return self._namespace or self._client.namespace

--- a/noseiquela_orm/fields.py
+++ b/noseiquela_orm/fields.py
@@ -175,8 +175,8 @@ class KeyField(BaseKey):
 class ParentKey(BaseKey):
     def __init__(self, parent, project=None, namespace=None, required=False) -> None:
         self._parent_entity = parent
-        project = project or self._parent_entity._project
-        namespace = namespace or self._parent_entity._namespace
+        project = project or self._parent_entity.project
+        namespace = namespace or self._parent_entity.namespace
         super().__init__(project=project, namespace=namespace)
 
     @property


### PR DESCRIPTION
```python
from noseiquela_orm import (Entity, ParentKey, BooleanField, FloatField,
                 IntegerField, StringField, ListField, DictField,
                 DateTimeField)

class Customer(Entity):
    name = StringField(required=True)
    age = IntegerField(required=True)
    is_deleted = BooleanField(default=False, required=True)

class CustomerAddress(Entity):
    __kind__ = "address"
    __parent__ = ParentKey(Customer, required=True)

    number = IntegerField(required=True)
    address_one = StringField(required=True)
    address_one = StringField()
    is_default = BooleanField(required=True)
    is_deleted = BooleanField(default=False, required=True)

    class Meta:
        project = "other-project"
        namespace = "other-namespace"
```

so it overwrites only for that model