### PR TITLE
fix: fix Python 3.8 support and extend CI tests

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   test:
-    name: Run unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    name: Run unit tests on Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -15,7 +20,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install project's requirements
         run: pip install -r requirements-dev.txt
       - name: Run tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Database :: Front-Ends
     Topic :: Software Development :: Libraries :: Python Modules
 

--- a/src/noseiquela_orm/utils/collections.py
+++ b/src/noseiquela_orm/utils/collections.py
@@ -22,13 +22,6 @@ def merge_dicts(
     ```
 
     This function backports the dictionary union operator from python3.9 to python3.8.
-
-    Args:
-        left (Dict): The first dictionary to merge.
-        right (Dict): The second dictionary to merge.
-
-    Returns:
-        Dict: A new dict with keys from both left and right.
     """
 
     # TODO(python3.9): replace this function with the dictionary union operator when

--- a/src/noseiquela_orm/utils/collections.py
+++ b/src/noseiquela_orm/utils/collections.py
@@ -1,4 +1,4 @@
-from typing import Dict, TypeVar, Union
+from typing import Dict, TypeVar
 
 _Keys = TypeVar("_Keys")
 _Values = TypeVar("_Values")
@@ -8,7 +8,7 @@ def merge_dicts(
     left: Dict[_Keys, _Values],
     right: Dict[_Keys, _Values],
     /,
-) -> Dict[Union[_Keys, _Keys], Union[_Values, _Values]]:
+) -> Dict[_Keys, _Values]:
     """Merge two dictionaries together into a new dict with keys from both dicts.
 
     Note that the values from the right dict will overwrite the values from the left one

--- a/src/noseiquela_orm/utils/collections.py
+++ b/src/noseiquela_orm/utils/collections.py
@@ -1,0 +1,36 @@
+from typing import Dict, TypeVar, Union
+
+_Keys = TypeVar("_Keys")
+_Values = TypeVar("_Values")
+
+
+def merge_dicts(
+    left: Dict[_Keys, _Values],
+    right: Dict[_Keys, _Values],
+    /,
+) -> Dict[Union[_Keys, _Keys], Union[_Values, _Values]]:
+    """Merge two dictionaries together into a new dict with keys from both dicts.
+
+    Note that the values from the right dict will overwrite the values from the left one
+    if the same key is present in both dicts:
+
+    ```python
+    >>> left = {"a": 1, "b": 2}
+    >>> right = {"b": 3, "c": 4}
+    >>> merge_dicts(left, right)
+    {"a": 1, "b": 3, "c": 4}
+    ```
+
+    This function backports the dictionary union operator from python3.9 to python3.8.
+
+    Args:
+        left (Dict): The first dictionary to merge.
+        right (Dict): The second dictionary to merge.
+
+    Returns:
+        Dict: A new dict with keys from both left and right.
+    """
+
+    # TODO(python3.9): replace this function with the dictionary union operator when
+    # support for python3.8 is dropped
+    return {**left, **right}

--- a/tests/unit/test_collections.py
+++ b/tests/unit/test_collections.py
@@ -1,0 +1,17 @@
+import pytest
+
+from noseiquela_orm.utils.collections import merge_dicts
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ({}, {}, {}),
+        ({"a": 1}, {}, {"a": 1}),
+        ({}, {"a": 1}, {"a": 1}),
+        ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
+        ({"a": 1, "b": 2}, {"b": 3, "c": 4}, {"a": 1, "b": 3, "c": 4}),
+    ],
+)
+def test_merge_dicts(left, right, expected):
+    assert merge_dicts(left, right) == expected


### PR DESCRIPTION
# Fix Python 3.8 support and extend CI tests

This PR:

- correctly adds support for Python 3.8 by replacing [Python 3.9's `dict` union operator](https://peps.python.org/pep-0584/) with a custom utility function
- extends the CI tests to test all supported Python versions
- extends the list of supported Python versions to include Python 3.11 and 3.12